### PR TITLE
CleanUp sync code a bit

### DIFF
--- a/Communications.lua
+++ b/Communications.lua
@@ -251,10 +251,12 @@ end
 AstralEvents:Register('PLAYER_LOGIN', GuildVersionCheckOnLogin, 'versionCheck_login_guild')
 
 local function GroupVersionCheckOnJoin()
-	if IsInRaid() then
-		AstralComs:NewMessage('AstralKeys', 'versionCheck ' .. e.CLIENT_VERSION, 'RAID')
-	elseif (IsInGroup() and not IsInGroup(LE_PARTY_CATEGORY_INSTANCE) == 'INSTANCE_CHAT') then
-		AstralComs:NewMessage('AstralKeys', 'versionCheck ' .. e.CLIENT_VERSION, 'PARTY')
+	if GetNumGroupMembers() > 1 then
+		if IsInRaid() and select(2, IsInInstance()) ~= "scenario" and select(2, IsInInstance()) ~= "pvp" then
+			AstralComs:NewMessage('AstralKeys', 'versionCheck ' .. e.CLIENT_VERSION, 'RAID')
+		elseif (IsInGroup() and not IsInGroup(LE_PARTY_CATEGORY_INSTANCE) == 'INSTANCE_CHAT') then
+			AstralComs:NewMessage('AstralKeys', 'versionCheck ' .. e.CLIENT_VERSION, 'PARTY')
+		end
 	end
 end
 AstralEvents:Register('GROUP_ROSTER_UPDATE', GroupVersionCheckOnJoin, 'versionCheck_login_group')


### PR DESCRIPTION
- send addon messages to group only if you are not alone
- do not send addon messages to the raid channel if inside a warfront or battleground to avoid error messages